### PR TITLE
fixing issue on service TPTV

### DIFF
--- a/packages/envied/src/envied/services/TPTV/__init__.py
+++ b/packages/envied/src/envied/services/TPTV/__init__.py
@@ -263,7 +263,7 @@ class TPTV(Service):
 
 
     def get_tracks(self, title: Union[Movie, Episode]) -> Tracks:
-        playlist = f"https://edge.api.brightcove.com/playback/v1/accounts/6272132012001/videos/{title.data.get('id')}"
+        playlist = f'https://edge.api.brightcove.com/playback/v1/accounts/6272132012001/videos/{title.data.get("id")}'
 
         headers = {
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0',


### PR DESCRIPTION
Change the inner quotes around  "id"  to single quotes  'id' 

you will get the following error without this fix.

 File "C:\Users\user\TwinVine\packages\envied\src\envied\services\TPTV\__init__.py", line 266
    playlist = f"https://edge.api.brightcove.com/playback/v1/accounts/6272132012001/videos/{title.data.get("id")}"
                                                                                                            ^^
SyntaxError: f-string: unmatched '('