### PR TITLE
Fix small typo on init AMZN

### DIFF
--- a/packages/envied/src/envied/services/AMZN/__init__.py
+++ b/packages/envied/src/envied/services/AMZN/__init__.py
@@ -553,7 +553,7 @@ class AMZN(Service):
 
     def get_widevine_license(self, *, challenge: bytes, title: Title_T, track) -> None:
         response = self.session.post(
-            url=self.endpoints["license"],
+            url=self.endpoints["licence"],
             params={
                 "asin": title.id,
                 "consumptionType": "Streaming",


### PR DESCRIPTION
Hello,
After some debugging i notice amzn (or maybe you wanted to put all with licence and instead you put license?) changed license to licence.
