### PR TITLE
Repack decrypted tracks so video isn't muxed as encrypted (encv)

### DIFF
--- a/packages/envied/src/envied/commands/dl.py
+++ b/packages/envied/src/envied/commands/dl.py
@@ -2318,6 +2318,12 @@ class dl:
                                 drm.decrypt(track.path)
                                 if not isinstance(drm, MonaLisa):
                                     has_decrypted = True
+                                    # Decryption can leave a stale encrypted
+                                    # sample-description (encv) beside the clean
+                                    # one; mkvmerge would then mux the track as
+                                    # encrypted. Repack to keep only the decoded
+                                    # stream.
+                                    track.needs_repack = True
                                 events.emit(events.Types.TRACK_REPACKED, track=track)
                             else:
                                 self.log.warning(

--- a/packages/envied/src/envied/core/manifests/dash.py
+++ b/packages/envied/src/envied/core/manifests/dash.py
@@ -560,6 +560,10 @@ class DASH:
             progress(downloaded="Decrypting", completed=0, total=100)
             drm.decrypt(save_path)
             track.drm = None
+            # Decryption can leave a stale encrypted sample-description
+            # (encv) beside the clean one; mkvmerge would then mux the
+            # track as encrypted. Repack to keep only the decoded stream.
+            track.needs_repack = True
             events.emit(events.Types.TRACK_DECRYPTED, track=track, drm=drm, segment=None)
             progress(downloaded="Decrypting", advance=100)
 

--- a/packages/envied/src/envied/core/manifests/hls.py
+++ b/packages/envied/src/envied/core/manifests/hls.py
@@ -764,6 +764,11 @@ class HLS:
                         drm.decrypt(file)
                     merge(to=merged_path, via=files, delete=True, include_map_data=True)
 
+                # Decryption can leave a stale encrypted sample-description
+                # (encv) beside the clean one; mkvmerge would then mux the
+                # track as encrypted. Repack to keep only the decoded stream.
+                track.needs_repack = True
+
                 events.emit(events.Types.TRACK_DECRYPTED, track=track, drm=drm, segment=decrypted_path)
 
                 return decrypted_path

--- a/packages/envied/src/envied/core/manifests/ism.py
+++ b/packages/envied/src/envied/core/manifests/ism.py
@@ -391,6 +391,10 @@ class ISM:
             progress(downloaded="Decrypting", completed=0, total=100)
             session_drm.decrypt(save_path)
             track.drm = None
+            # Decryption can leave a stale encrypted sample-description
+            # (encv) beside the clean one; mkvmerge would then mux the
+            # track as encrypted. Repack to keep only the decoded stream.
+            track.needs_repack = True
             events.emit(events.Types.TRACK_DECRYPTED, track=track, drm=session_drm, segment=None)
             progress(downloaded="Decrypting", advance=100)
 

--- a/packages/envied/src/envied/core/tracks/track.py
+++ b/packages/envied/src/envied/core/tracks/track.py
@@ -365,6 +365,11 @@ class Track:
                             progress(downloaded="Decrypting", completed=0, total=100)
                             drm.decrypt(save_path)
                             self.drm = None
+                            # Decryption can leave a stale encrypted
+                            # sample-description (encv) beside the clean one;
+                            # mkvmerge would then mux the track as encrypted.
+                            # Repack to keep only the decoded stream.
+                            self.needs_repack = True
                             events.emit(events.Types.TRACK_DECRYPTED, track=self, drm=drm, segment=None)
                             progress(downloaded="Decrypted", completed=100)
 


### PR DESCRIPTION
## Problem

Downloaded titles play **audio only**; the video is black or throws a
codec error in every player. `ffprobe` reports the video codec as
`encv` (still encrypted) and `mkvmerge` stores it as `V_QUICKTIME`.

## Root cause

After DRM decryption the merged MP4 keeps the original **encrypted**
sample description (`encv`, with `sinf`/`schm`/`tenc`) in the file
alongside the clean decoded one (`avc1`). The samples themselves are
decrypted, but the container now advertises two video sample entries.
Standalone players happen to pick the `avc1` entry, but `mkvmerge`
picks the first (`encv`) entry and muxes the track flagged as
encrypted, so the muxed file has unplayable video.

This is not a key or scheme problem: audio and video share the same
KID and `cenc` scheme, and audio muxes fine. It is also independent of
the decrypter (shaka-packager and mp4decrypt both leave the stray
header). A plain `ffmpeg -c copy` collapses it to a single clean
stream.

envied already has an FFmpeg repack step that does exactly that, but it
only runs when `track.needs_repack` is set, which the streaming
manifest handlers never did.

## Fix

Set `track.needs_repack = True` immediately after `drm.decrypt(...)` at
every decrypt site (DASH, HLS and ISM handlers, plus the direct-URL and
deferred-CDM paths in `track.py` and `commands/dl.py`), so decrypted
tracks are always repacked before muxing.

## Testing

Verified end to end on an All 4 (DASH / Widevine) title:

- Before: muxed video track is `encv`, unknown codec, will not decode.
- After: muxed video track is clean H.264 and decodes correctly at
  1080p.
