### PR TITLE
Run VineFeeder widget updates on the GUI thread (fixes macOS crash)

### DIFF
--- a/packages/vinefeeder/src/vinefeeder/__main__.py
+++ b/packages/vinefeeder/src/vinefeeder/__main__.py
@@ -391,9 +391,7 @@ class VineFeeder(QWidget):
 
 
     
-    def load_service(self, service_name: str):
-        self.update_batch_file_indicator()
-
+    def load_service(self, service_name: str, text_to_pass=None):
         meta = self.available_services.get(service_name)
         if not meta:
             console.print(f"[{catppuccin_mocha['text2']}]Service {service_name} not found![/]")
@@ -414,19 +412,14 @@ class VineFeeder(QWidget):
             hlg_status = self.available_services_hlg_status[service_name]
             options = self.available_services_options[service_name]
 
-            text = self.search_url_entry.text().strip()
-            text_to_pass = text if text else None
-
             if hasattr(loader_instance, "receive"):
                 if text_to_pass:
                     if "http" in text_to_pass:
                         loader_instance.receive(1, text_to_pass, None, hlg_status, options)
-                        self.clear_search_box()
                         loader_instance.clean_terminal()
                         sys.exit(0)
                     else:
                         loader_instance.receive(3, text_to_pass, None, hlg_status, options)
-                        self.clear_search_box()
                         loader_instance.clean_terminal()
                         sys.exit(0)
                 else:
@@ -621,10 +614,23 @@ class VineFeeder(QWidget):
             sys.exit(0)
 
     def run_load_service_thread(self, service_name):
-        """Start a new thread to load the service."""
-        return lambda: threading.Thread(
-            target=self.load_service, args=(service_name,)
-        ).start()
+        """Return the button handler that loads a service.
+
+        All widget access stays here, on the GUI thread. macOS aborts
+        the process if a Qt widget is touched from a worker thread, so
+        the box is read and cleared here and the thread is handed plain
+        text only.
+        """
+        def handler():
+            self.update_batch_file_indicator()
+            text = self.search_url_entry.text().strip()
+            self.search_url_entry.clear()
+            threading.Thread(
+                target=self.load_service,
+                args=(service_name, text or None),
+            ).start()
+
+        return handler
 
     
 


### PR DESCRIPTION
## Problem

On macOS, entering a URL (or a search term) and selecting a service in
the VineFeeder GUI closes the app instantly. The crash report shows a
`SIGTRAP` in `dispatch_assert_queue` on a **worker thread**, reached via
`QLineEdit.clear()` -> `NSTextInputContext discardMarkedText` -> the
Text Services Manager.

## Root cause

`load_service` runs on a `threading.Thread`, but it calls
`clear_search_box()` (`QLineEdit.clear()`) and `update_batch_file_
indicator()` (`QLabel.setText`/`setStyleSheet`). Qt requires all widget
access to happen on the GUI thread. macOS 26 now enforces this in the
text-input layer with a hard assertion, so the process aborts instead
of tolerating the violation (which is why it may have worked on older
macOS/Linux).

## Fix

Move all widget access into the button handler, which runs on the GUI
thread. It refreshes the batch indicator, reads and clears the search
box, then starts the worker thread with a plain text argument.
`load_service` now receives that text and no longer touches any widget.

## Testing

Exercised the real `VineFeeder` widget on the native macOS Cocoa Qt
backend: the button handler clears the box on the main thread and the
worker runs off-main with the text passed through, with no abort.
