### PR TITLE
fix(ALL4): repack video so it isn't muxed as encrypted (scoped follow-up to #15)

### DIFF
--- a/packages/envied/src/envied/services/ALL4/__init__.py
+++ b/packages/envied/src/envied/services/ALL4/__init__.py
@@ -243,6 +243,11 @@ class ALL4(Service):
         tracks = DASH.from_url(self.manifest, self.session).to_tracks(title.language)
         tracks.videos[0].data = data
 
+        # All 4 video carries a stale encrypted sample entry beside the
+        # decrypted one; repack so mkvmerge does not mux it as encrypted.
+        for video in tracks.videos:
+            video.needs_repack = True
+
         # manifest subtitles are sometimes empty even if they exist
         # so we clear them and add the subtitles manually
         tracks.subtitles.clear()


### PR DESCRIPTION
Scoped follow-up to #15, addressing your review: this sets
`needs_repack` on ALL4 video tracks only, so no other service is
affected.

## Problem

All 4 delivers video with a stale encrypted sample description (`encv`)
sitting beside the decrypted one. The samples are decrypted, but the
container still advertises the encrypted entry, so `mkvmerge` muxes the
track as `V_QUICKTIME`/`encv` and the output plays audio only (the video
is rejected by players).

## Fix

In `services/ALL4/get_tracks`, flag the video tracks `needs_repack` so
the existing FFmpeg repack collapses them to a single clean stream
before muxing. This uses the same per-service idiom as `NF`, `CR` and
`ATVP`, and touches nothing outside ALL4.

The previous version in #15 set the flag in the shared DASH/HLS/ISM
handlers, which made every service repack; that is reverted and replaced
by this.

## Testing

Verified on an All 4 (DASH/Widevine) title at 1080p: before, the muxed
video is `encv` and will not decode; after, it is clean H.264 and plays.
